### PR TITLE
Save Settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
   <input id="mobileInput" placeholder="Enter memo here"></input>
   <h1 id="memo">memo:</h1>
   <div id="underScramble">
-    <h2 id="scramble"><span id="scramblebox">click here to scramble</span></h2>
     <h1 id="timer"></h1>
+    <h2 id="scramble"><span id="scramblebox">click here to scramble</span></h2>
     <br>
     <button id="scrambleButton">next scramble</button>
     <button id="enterscramble">enter scramble</button>

--- a/script.js
+++ b/script.js
@@ -503,10 +503,10 @@ document.querySelector("#clock").addEventListener("click", function() {
 // show the timer when checkbox is clicked
 document.querySelector("#timerButton").addEventListener("click", function() {
   if (document.querySelector("#timerButton").checked) {
-    document.querySelector("#timer").style.display = "block";
+    document.querySelector("#timer").style.visibility = "visible";
   }
   else{
-    document.querySelector("#timer").style.display = "none";
+    document.querySelector("#timer").style.visibility = "hidden";
   }
   syncSettingsUrl();
 });

--- a/script.js
+++ b/script.js
@@ -418,15 +418,15 @@ function toggleVisibility() {
 }
 
 document.querySelector("#letters").addEventListener("click", function() {
-  if (true) {
-    l = ["L","A","B","C","D","E","F","G","H","I","J","K"];
-  }
+  l = ["L","A","B","C","D","E","F","G","H","I","J","K"];
+  syncSettingsUrl();
 });
+
 document.querySelector("#ryan").addEventListener("click", function() {
-  if (true) {
-    l = ["0","1","2","3","4","5","6","E","D","C","B","A"];
-  }
+  l = ["0","1","2","3","4","5","6","E","D","C","B","A"];
+  syncSettingsUrl();
 });
+
 document.querySelector("#executionTrainer").addEventListener("click", function() {
   if (document.querySelector("#executionTrainer").checked) {
     executionMode=true
@@ -434,6 +434,7 @@ document.querySelector("#executionTrainer").addEventListener("click", function()
   else{
     executionMode=false
   }
+  syncSettingsUrl();
 });
 
 document.querySelector("#executionOnBlack").addEventListener("click", function() {
@@ -443,6 +444,7 @@ document.querySelector("#executionOnBlack").addEventListener("click", function()
   else{
     executeOnBlack=false
   }
+  syncSettingsUrl();
 });
 
 document.querySelector("#swapRPair").addEventListener("click", function() {
@@ -452,6 +454,7 @@ document.querySelector("#swapRPair").addEventListener("click", function() {
   else{
     swapRPair=false
   }
+  syncSettingsUrl();
 });
 
 function generateScramble() {
@@ -505,7 +508,38 @@ document.querySelector("#timerButton").addEventListener("click", function() {
   else{
     document.querySelector("#timer").style.display = "none";
   }
+  syncSettingsUrl();
 });
+
+function applySettingsFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  const settingsParam = params.get("settings");
+  const allSettings = ["executionTrainer", "executionOnBlack", "timerButton", "swapRPair"];
+  if (settingsParam !== null) {
+    const enabled = settingsParam.split(",").map(s => s.trim()).filter(s => s.length > 0);
+    allSettings.forEach(id => {
+      const checkbox = document.getElementById(id);
+      const isChecked = enabled.includes(id);
+      checkbox.checked = isChecked;
+      checkbox.dispatchEvent(new Event("click"));
+    });
+    const memoToken = enabled.find(s => s.startsWith('memoType_'));
+    if (memoToken) {
+      const memoId = memoToken.replace('memoType_', '');
+      const radio = document.getElementById(memoId);
+      if (radio) { radio.checked = true; radio.dispatchEvent(new Event("click")); }
+    }
+  }
+}
+
+function syncSettingsUrl() {
+  const ids = ['executionTrainer', 'executionOnBlack', 'timerButton', 'swapRPair'];
+  const checked = ids.filter(id => document.getElementById(id).checked);
+  const memoType = document.querySelector('input[name="memoType"]:checked').value;
+  if (memoType !== 'letters') checked.push('memoType_' + memoType);
+  const value = checked.join(',');
+  history.replaceState(null, '', value ? '?settings=' + value : window.location.pathname);
+}
 
 // all the code for the timer
 let timerInterval;
@@ -543,3 +577,4 @@ function resetTimer() {
   updateTimer();
 }
 startTimer()
+applySettingsFromURL();

--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ body {
   color: red;
 }
 #timer {
-  visibility: visible
+  visibility: hidden
 }
 .highlight {
   background-color: rgba(255, 255, 0, 0.4);

--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ body {
   color: red;
 }
 #timer {
-  display: none;
+  visibility: visible
 }
 .highlight {
   background-color: rgba(255, 255, 0, 0.4);


### PR DESCRIPTION
Hey Josh,

The primary feature of this PR is the ability to save settings. When settings are changed from their default value, it updates the url with query params (e.g, toggling the timer on adds this to the url: "?settings=timerButton"). At load time, these values are parsed and settings are applied. Users can then bookmark a version of the site that has their preferred settings. I always tend to change the same few settings when practicing, so this should help reduce that friction.

I also added a minor UX change with the timer. Previously toggling it on/off changed if it was displayed or not. This caused the rest of the page to shift up/down, and was a little jarring. I moved the timer to go above the scramble, and have only its visibility toggled. So turning it on/off doesn't move the rest of the page. 

Let me know if you have any questions or concerns!